### PR TITLE
added backwards compatibility for jdk 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ In both cases, a webhook endpoint needs to be set up to keep data in sync.
 
 ## Requirements
 
-Java 1.8 or later.
+Java 1.7 or later. To build the project for 1.7 in gradle,
+ you need to have jdk 9+ this uses flags for backwards compatibility.
 
 ## Installation
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,10 @@ plugins {
 }
 
 group 'com.ivelum'
-version '0.15.0'
+version '0.16.0'
 
-sourceCompatibility = 1.8
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
this will allow for us to use this client jar in our jdk7 runtime. please compile with jdk 9+ which allows gradle to instruct the compiler with the proper flags for backwards compatibility. 